### PR TITLE
Allow samples/run_workers.py to run a configurable number of workers, documentation updates

### DIFF
--- a/python/samples/run_workers.py
+++ b/python/samples/run_workers.py
@@ -1,52 +1,55 @@
-# Having set up a temporal server,
-# you can start 5 sample workers with this script:
-#    poetry run python samples/run_workers.py
-import sys
-
-from batch_worker import BatchWorkerClient
-
 try:
+    import argparse
     import asyncio
-    import multiprocessing
     import logging
+    import multiprocessing
+    import sys
 
     from temporalio.client import Client
     from temporalio.worker import Worker
 
     from batch_orchestrator import BatchOrchestrator, process_page
+    from batch_worker import BatchWorkerClient
 
     # Import our registry of page processors which are registered with @page_processor.
     # Without importing this, they will not be registered.
-    import samples.lib.inflate_product_prices_page_processor # noqa: F401
+    import samples.lib.inflate_product_prices_page_processor  # noqa: F401
 except ModuleNotFoundError as e:
     print(f"""
-This script requires poetry.  `poetry run python samples/perform_sql_batch_migration.py`.
-But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry.
-Original error: {e}
-        """)
+        This script requires poetry.  `poetry run python samples/run_workers.py`.
+        But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry.
+        Original error: {e}
+    """)
     sys.exit(1)
+
+logging.basicConfig(level=logging.INFO)
 
 interrupt_event = asyncio.Event()
 
+TEMPORAL_HOST = "localhost:7233"
+TASK_QUEUE = "my-task-queue"
+
 
 async def worker_async():
-    logging.basicConfig(level=logging.INFO)
-    # Set up the connection to temporal-server.
-    host = "localhost:7233"
+    """
+    Start a worker to handle BatchOrchestrator workflows, including any registered page_processor
+    activities.
+    """
     try:
-        temporal_client = await Client.connect(host)
+        # Set up the connection to temporal-server.
+        temporal_client = await Client.connect(TEMPORAL_HOST)
         temporal_client = BatchWorkerClient.register(temporal_client)
     except RuntimeError as e:
-        print(f"""
-Could not connect to temporal-server at {host}.  Check the README.md Python Quick Start if you need guidance.
-Original error: {e}
-           """)
+        logging.error(f"""
+            Could not connect to temporal-server at {TEMPORAL_HOST}. Check the README.md Python Quick Start if you need guidance.
+            Original error: {e}
+        """)
         sys.exit(1)
 
     # Run a worker for the activities and workflow
     async with Worker(
         temporal_client,
-        task_queue="my-task-queue",
+        task_queue=TASK_QUEUE,
         activities=[process_page],
         workflows=[BatchOrchestrator],
         debug_mode=True,
@@ -59,10 +62,10 @@ Original error: {e}
 def worker():
     asyncio.run(worker_async())
 
-def main():
+def main(num_processes: int):
     processes = []
 
-    for _ in range(5): 
+    for _ in range(num_processes):
         p = multiprocessing.Process(target=worker)
         p.start()
         processes.append(p)
@@ -70,7 +73,19 @@ def main():
     return processes
 
 if __name__ == "__main__":
-    processes = main()
+    parser = argparse.ArgumentParser(
+        description="Run a configurable number of Temporal workers to handle BatchOrchestrator workflows.",
+        usage="poetry run python samples/run_workers.py",
+    )
+    parser.add_argument(
+        "--num_processes",
+        type=int,
+        default=5,
+        help="Number of worker processes to start.",
+    )
+    args = parser.parse_args()
+
+    processes = main(num_processes=args.num_processes)
 
     try:
         for p in processes:


### PR DESCRIPTION
Proposal for a few small updates to the `run_workers.py` example engine, to help with newcomers to the repository getting started:

- group all imports in the poetry try/catch block, rearrange slightly to highlight the samples registry import
- split the temporal host and queue out to top-level constants, for configurability
- use logging instead of print, and configure logging at the top instead of class level
- allow the number of worker processes to be configured via CLI, in case any developers want to experiment with this
