### PR TITLE
Replay Hackathon 2025 - Add demo streamlit progress viewer

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -16,6 +16,7 @@ packages = [
 python = "^3.10"
 temporalio = "^1.5.0"
 inflect = "^7.0.0"
+streamlit = "^1.42.2"
 
 [tool.pytest.ini_options]
 asyncio_mode = "strict"

--- a/python/samples/progress_viewer.py
+++ b/python/samples/progress_viewer.py
@@ -1,0 +1,171 @@
+import asyncio
+import os
+import uuid
+from datetime import datetime
+from tempfile import NamedTemporaryFile
+
+import streamlit as st
+from batch_orchestrator import BatchOrchestratorInput
+from batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
+from batch_orchestrator_io import BatchOrchestratorProgress
+from samples.lib.inflate_product_prices_page_processor import (
+    ConfigArgs,
+    InflateProductPrices,
+)
+from samples.lib.product_db import ProductDB
+from temporalio.client import Client, WorkflowExecutionStatus
+
+TEMPORAL_HOST = "localhost:7233"
+
+DEFAULT_NUM_ITEMS = 2000
+DEFAULT_NUM_PAGES = 200
+PAGES_PER_RUN = None
+
+
+# To run: "poetry run streamlit run samples/progress_viewer.py"
+
+async def configure_temporal_client() -> Client | None:
+    try:
+        temporal_client = await Client.connect(TEMPORAL_HOST)
+        return temporal_client
+    except RuntimeError as e:
+        st.error(f"""
+            Could not connect to temporal-server at {TEMPORAL_HOST}.  Check the README.md Python Quick Start if you need guidance.
+            Original error: {e}
+           """)
+
+
+# https://discuss.streamlit.io/t/how-do-you-hide-buttons-after-clicking-them/86671/2
+def hide_buttons():
+    st.markdown(
+        """
+        <style>
+        button[data-testid="stBaseButton-secondary"] {
+            display: none;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def create_example_database(num_items: int = DEFAULT_NUM_ITEMS):
+    db_file = NamedTemporaryFile(suffix="_my_product.db", delete=False)
+    print(f"Creating a temporary database in {db_file.name}")
+    db_connection = ProductDB.get_db_connection(db_file.name)
+
+    ProductDB.populate_table(db_connection, num_records=num_items)
+    return db_file
+
+
+def visualise_progress(
+    status_widget,
+    progress_bar,
+    progress_info: BatchOrchestratorProgress,
+    page_estimate: int,
+):
+    status_widget.update(
+        label=f"Processing {progress_info.num_processing_pages} pages, completed {progress_info.num_completed_pages} pages"
+    )
+
+    estimated_completion_percent = progress_info.num_completed_pages / page_estimate
+    progress_bar.progress(estimated_completion_percent)
+
+
+def visualise_finished():
+    st.balloons()
+
+
+async def run_batch_checker(handle: BatchOrchestratorHandle, num_items, page_size):
+    status = st.status("Checking batch progress....")
+    progress = st.progress(0)
+
+    # Sadly we won't know this in a real world scenario....
+    page_estimate = int(num_items / page_size) + 1
+
+    while True:
+        await asyncio.sleep(1)
+        progress_details = await handle.get_progress()
+        visualise_progress(
+            status_widget=status,
+            progress_bar=progress,
+            progress_info=progress_details,
+            page_estimate=page_estimate,
+        )
+        if progress_details.is_finished:
+            progress.empty()
+            duration = (
+                datetime.now()
+                - datetime.fromtimestamp(progress_details._start_timestamp)
+            ).total_seconds()
+            status.update(
+                label=f"Batch processing complete: {progress_details.num_completed_pages} pages processed in {duration} seconds",
+                state="complete",
+            )
+            visualise_finished()
+            break
+
+
+async def app():
+    st.title("Batch Orchestrator Progress Viewer")
+    client = await configure_temporal_client()
+
+    if client:
+        try:
+            col1, col2 = st.columns(2)
+            with col1:
+                num_items = st.number_input(
+                    "Number of database items to simulate",
+                    min_value=1,
+                    max_value=1000000,
+                    value=DEFAULT_NUM_ITEMS,
+                    step=500,
+                )
+            with col2:
+                page_size = st.number_input(
+                    "Number of pages for batch processing",
+                    min_value=1,
+                    max_value=1000000,
+                    value=DEFAULT_NUM_PAGES,
+                    step=50,
+                )
+            _, middle, _ = st.columns(3)
+            with middle:
+                button = st.button("Start batch orchestra! :violin:")
+
+            db_file = create_example_database(num_items)
+
+            args = ConfigArgs(db_file=db_file.name)
+            handle = await BatchOrchestratorClient(client).start(
+                BatchOrchestratorInput(
+                    max_parallelism=5,
+                    page_processor=BatchOrchestratorInput.PageProcessorContext(
+                        name=InflateProductPrices.__name__,
+                        page_size=page_size,
+                        args=args.to_json(),
+                    ),
+                    pages_per_run=PAGES_PER_RUN,
+                ),
+                id=f"inflate_product_prices-{str(uuid.uuid4())}",
+                task_queue="my-task-queue",
+            )
+
+            if button:
+                hide_buttons()
+                middle.link_button(
+                    "View in Temporal",
+                    icon="🔗",
+                    url=f"http://localhost:8233/namespaces/default/workflows/{handle.workflow_handle.id}/{handle.workflow_handle.first_execution_run_id}/history",
+                )
+                await run_batch_checker(handle, num_items, page_size)
+
+        finally:
+            os.remove(db_file.name)
+            info = await handle.workflow_handle.describe()
+            if info.status == WorkflowExecutionStatus.RUNNING:
+                print("\nCanceling workflow")
+                await handle.workflow_handle.cancel()
+
+
+if __name__ == "__main__":
+    asyncio.run(app())


### PR DESCRIPTION

## Background
For Replay London 2025, we set out to make it easier to visualise the progress of a running batch orchestra job outside of the terminal. We also wanted to add some tooling to make it easier for newcomers to get started with running a demo, and understanding how modifying parameters such as number of database items/page size affects the speed of batch orchestration.


## Outcome
This example wraps the current runner from `perform_sql_batch_migration.py` inside a streamlit app, which supports modifying the number of items and page size that the batch migration example is run across. Each time these parameters are modified, a button will show allowing the user to run the batch migration, as well as view the running workflows in the Temporal UI.
**Usage:**
```
poetry run streamlit run samples/progress_viewer.py
```

## Caveats
This is hacky code written in a short hackathon time window, so isn't production ready 😉 

In addition, the visualiser makes use of the fact that we know the number of example items in the database ahead of time to calculate the completion percentage of the progress bar - in a real world scenario, this number of total items wouldn't be available without additional querying (which is what the batch orchestra is designed to avoid..)
