### PR TITLE
Make both PIP and poetry work

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -53,6 +53,12 @@ If you want to run tests and samples:
 
     pip install -r requirements-dev.txt
 
+Then use pytest to run the tests:
+
+    pytest tests/
+
+You may also run the samples, which are currently the best place to get an idea of how to implement.  See the [samples README](./samples/README.md)
+
 # Page processors
 
 The main thing you implement is a page processor annotated with `@page_processor`.

--- a/python/batch_orchestra/batch_orchestrator.py
+++ b/python/batch_orchestra/batch_orchestrator.py
@@ -6,16 +6,14 @@ from datetime import timedelta
 from typing import Dict, Optional, Set, Type
 
 import inflect
-
-from .internal.state import ContinueAsNewState, EnqueuedPage, PageTrackerData
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError, CancelledError
 
-from .batch_processor import PageProcessor, get_page_processor
-from .batch_processor import BatchPage, process_page
 from .batch_orchestrator_io import BatchOrchestratorInput, BatchOrchestratorProgress
+from .batch_processor import BatchPage, PageProcessor, get_page_processor, process_page
 from .batch_tracker import track_batch_progress
+from .internal.state import ContinueAsNewState, EnqueuedPage, PageTrackerData
 
 #
 # batch_orchestrator library

--- a/python/batch_orchestra/batch_orchestrator.py
+++ b/python/batch_orchestra/batch_orchestrator.py
@@ -6,13 +6,16 @@ from datetime import timedelta
 from typing import Dict, Optional, Set, Type
 
 import inflect
-from batch_orchestrator_io import BatchOrchestratorInput, BatchOrchestratorProgress
-from batch_processor import BatchPage, PageProcessor, get_page_processor, process_page
-from batch_tracker import track_batch_progress
-from internal.state import ContinueAsNewState, EnqueuedPage, PageTrackerData
+
+from .internal.state import ContinueAsNewState, EnqueuedPage, PageTrackerData
 from temporalio import workflow
 from temporalio.common import RetryPolicy
 from temporalio.exceptions import ActivityError, ApplicationError, CancelledError
+
+from .batch_processor import PageProcessor, get_page_processor
+from .batch_processor import BatchPage, process_page
+from .batch_orchestrator_io import BatchOrchestratorInput, BatchOrchestratorProgress
+from .batch_tracker import track_batch_progress
 
 #
 # batch_orchestrator library

--- a/python/batch_orchestra/batch_orchestrator_client.py
+++ b/python/batch_orchestra/batch_orchestrator_client.py
@@ -1,10 +1,8 @@
 from datetime import timedelta
 from typing import Any, Mapping, Optional
-
+from .batch_orchestrator import BatchOrchestrator
+from .batch_orchestrator_io import BatchOrchestratorInput, BatchOrchestratorProgress
 import temporalio.client
-from batch_orchestrator import BatchOrchestrator
-from batch_orchestrator_io import BatchOrchestratorInput, BatchOrchestratorProgress
-
 
 # Use this to track and manipulate your batch job as it runs.  It's a thin wrapper around the workflow handle.
 class BatchOrchestratorHandle:

--- a/python/batch_orchestra/batch_orchestrator_client.py
+++ b/python/batch_orchestra/batch_orchestrator_client.py
@@ -1,8 +1,11 @@
 from datetime import timedelta
 from typing import Any, Mapping, Optional
+
+import temporalio.client
+
 from .batch_orchestrator import BatchOrchestrator
 from .batch_orchestrator_io import BatchOrchestratorInput, BatchOrchestratorProgress
-import temporalio.client
+
 
 # Use this to track and manipulate your batch job as it runs.  It's a thin wrapper around the workflow handle.
 class BatchOrchestratorHandle:

--- a/python/batch_orchestra/batch_processor.py
+++ b/python/batch_orchestra/batch_processor.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional
+from .batch_worker import BatchWorkerContext
 
 from batch_worker import BatchWorkerContext
 from temporalio import activity

--- a/python/batch_orchestra/batch_processor.py
+++ b/python/batch_orchestra/batch_processor.py
@@ -6,11 +6,12 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional
-from .batch_worker import BatchWorkerContext
 
 from batch_worker import BatchWorkerContext
 from temporalio import activity
 from temporalio.common import RetryPolicy
+
+from .batch_worker import BatchWorkerContext
 
 #
 # batch_processor library

--- a/python/batch_orchestra/batch_processor.py
+++ b/python/batch_orchestra/batch_processor.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Optional
 
-from batch_worker import BatchWorkerContext
 from temporalio import activity
 from temporalio.common import RetryPolicy
 

--- a/python/batch_orchestra/batch_tracker.py
+++ b/python/batch_orchestra/batch_tracker.py
@@ -5,9 +5,8 @@ from typing import Optional
 
 from temporalio import activity
 
-from .batch_processor import BatchWorkerContext
-
 from .batch_orchestrator_io import BatchOrchestratorProgress
+from .batch_processor import BatchWorkerContext
 
 _batch_tracker_registry = {}
 

--- a/python/batch_orchestra/batch_tracker.py
+++ b/python/batch_orchestra/batch_tracker.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
-from batch_orchestrator_io import BatchOrchestratorProgress
-from batch_processor import BatchWorkerContext
 from temporalio import activity
+
+from .batch_processor import BatchWorkerContext
+
+from .batch_orchestrator_io import BatchOrchestratorProgress
 
 _batch_tracker_registry = {}
 

--- a/python/batch_orchestra/internal/state.py
+++ b/python/batch_orchestra/internal/state.py
@@ -4,7 +4,7 @@ from asyncio import Future
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set
 
-from batch_processor import BatchPage
+from batch_orchestra.batch_processor import BatchPage
 
 
 @dataclass(kw_only=True)

--- a/python/batch_orchestra/internal/state.py
+++ b/python/batch_orchestra/internal/state.py
@@ -4,7 +4,7 @@ from asyncio import Future
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set
 
-from batch_orchestra.batch_processor import BatchPage
+from ..batch_processor import BatchPage
 
 
 @dataclass(kw_only=True)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Drew Hoskins"]
 license = "MIT"
 readme = "README.md"
 packages = [
-    { include = "**/*.py", from = "./batch_orchestra/"  }
+    { include = "batch_orchestra"  }
 ]
 
 [tool.poetry.dependencies]

--- a/python/samples/README.md
+++ b/python/samples/README.md
@@ -2,6 +2,8 @@
 
 To run a python sample, having already gone through the [quick start guide](../README.md)
 
+## Instructions if you use poetry
+
 Start some sample workers to process in parallel with:
 
     poetry run python samples/run_workers.py
@@ -9,3 +11,15 @@ Start some sample workers to process in parallel with:
 Start a workflow to run on those workers, for example with
 
     poetry run python samples/perform_sql_batch_migration.py
+
+## Instructions if you use pip
+
+Create an env as in [the Python README](../README.md) and activate it in two terminals.
+
+In one terminal, start some sample workers to process in parallel with:
+
+    python samples/run_workers.py
+
+In the other, a workflow to run on those workers, for example with
+
+    python samples/perform_sql_batch_migration.py

--- a/python/samples/lib/inflate_product_prices_page_processor.py
+++ b/python/samples/lib/inflate_product_prices_page_processor.py
@@ -6,8 +6,8 @@ from asyncio import sleep
 from dataclasses import asdict, dataclass
 from typing import Optional
 
+from batch_orchestra.batch_processor import BatchPage, BatchProcessorContext, PageProcessor, page_processor
 
-from batch_orchestra.batch_processor import BatchProcessorContext, BatchPage, PageProcessor, page_processor
 from .product_db import ProductDB
 
 

--- a/python/samples/lib/inflate_product_prices_page_processor.py
+++ b/python/samples/lib/inflate_product_prices_page_processor.py
@@ -6,8 +6,9 @@ from asyncio import sleep
 from dataclasses import asdict, dataclass
 from typing import Optional
 
-from batch_processor import BatchPage, BatchProcessorContext, PageProcessor, page_processor
-from lib.product_db import ProductDB
+
+from batch_orchestra.batch_processor import BatchProcessorContext, BatchPage, PageProcessor, page_processor
+from .product_db import ProductDB
 
 
 @dataclass

--- a/python/samples/pause_and_resume_processing.py
+++ b/python/samples/pause_and_resume_processing.py
@@ -9,6 +9,7 @@ try:
     from tempfile import NamedTemporaryFile
 
     import temporalio.service
+    from temporalio.client import Client
 
     # Add ../ to the path for PIP, so we can use absolute imports in the samples.
     sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))

--- a/python/samples/pause_and_resume_processing.py
+++ b/python/samples/pause_and_resume_processing.py
@@ -19,10 +19,13 @@ try:
     from samples.lib.inflate_product_prices_page_processor import ConfigArgs, InflateProductPrices
     from samples.lib.product_db import ProductDB
 except ModuleNotFoundError as e:
+    import traceback
     print(f"""
-This script requires poetry.  `poetry run python samples/pause_and_resume_processing.py`.
-But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry.
-Original error: {e}
+Failed to import modules.
+If you're using poetry, run `poetry run python samples/pause_and_resume_processing.py`.
+To set up poetry, or alternatively to set up a virtual environment, first see Python Quick Start in python/README.md.
+Original error:
+{traceback.format_exc()}
         """)
     sys.exit(1)
 

--- a/python/samples/pause_and_resume_processing.py
+++ b/python/samples/pause_and_resume_processing.py
@@ -9,11 +9,15 @@ try:
     from tempfile import NamedTemporaryFile
 
     import temporalio.service
-    from batch_orchestrator import BatchOrchestratorInput
-    from batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
-    from lib.inflate_product_prices_page_processor import ConfigArgs, InflateProductPrices
-    from lib.product_db import ProductDB
-    from temporalio.client import Client
+
+    # Add ../ to the path for PIP, so we can use absolute imports in the samples.
+    sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
+    from batch_orchestra.batch_orchestrator import BatchOrchestratorInput
+    from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
+
+    from samples.lib.inflate_product_prices_page_processor import InflateProductPrices, ConfigArgs
+    from samples.lib.product_db import ProductDB
 except ModuleNotFoundError as e:
     print(f"""
 This script requires poetry.  `poetry run python samples/pause_and_resume_processing.py`.

--- a/python/samples/pause_and_resume_processing.py
+++ b/python/samples/pause_and_resume_processing.py
@@ -15,8 +15,7 @@ try:
 
     from batch_orchestra.batch_orchestrator import BatchOrchestratorInput
     from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
-
-    from samples.lib.inflate_product_prices_page_processor import InflateProductPrices, ConfigArgs
+    from samples.lib.inflate_product_prices_page_processor import ConfigArgs, InflateProductPrices
     from samples.lib.product_db import ProductDB
 except ModuleNotFoundError as e:
     print(f"""

--- a/python/samples/perform_sql_batch_migration.py
+++ b/python/samples/perform_sql_batch_migration.py
@@ -2,10 +2,16 @@ import sys
 from asyncio import sleep
 from typing import Any, Optional
 
-from batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
-from batch_orchestrator_io import BatchOrchestratorProgress
-
 try:
+    import asyncio
+    from tempfile import NamedTemporaryFile
+    import uuid
+    import os
+    import sys
+
+    # Add ../ to the path for PIP, so we can use absolute imports in the samples.
+    sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
     import argparse
     import asyncio
     import os
@@ -13,10 +19,13 @@ try:
     from tempfile import NamedTemporaryFile
 
     import temporalio.service
-    from batch_orchestrator import BatchOrchestratorInput
-    from lib.inflate_product_prices_page_processor import ConfigArgs, InflateProductPrices
-    from lib.product_db import ProductDB
-    from temporalio.client import Client
+
+    from batch_orchestra.batch_orchestrator_io import BatchOrchestratorProgress
+    from batch_orchestra.batch_orchestrator import BatchOrchestratorInput
+    from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient,  BatchOrchestratorHandle
+
+    from samples.lib.inflate_product_prices_page_processor import InflateProductPrices, ConfigArgs
+    from samples.lib.product_db import ProductDB
 except ModuleNotFoundError as e:
     print(f"""
 This script requires poetry.  `poetry run python samples/perform_sql_batch_migration.py`.

--- a/python/samples/perform_sql_batch_migration.py
+++ b/python/samples/perform_sql_batch_migration.py
@@ -23,11 +23,14 @@ try:
     from batch_orchestra.batch_orchestrator_io import BatchOrchestratorProgress
     from samples.lib.inflate_product_prices_page_processor import ConfigArgs, InflateProductPrices
     from samples.lib.product_db import ProductDB
-except ModuleNotFoundError as e:
+except ModuleNotFoundError:
+    import traceback
     print(f"""
-This script requires poetry.  `poetry run python samples/perform_sql_batch_migration.py`.
-But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry.
-Original error: {e}
+Failed to import modules.
+If you're using poetry, run `poetry run python samples/perform_sql_batch_migration.py`.
+To set up poetry, or alternatively to set up a virtual environment, first see Python Quick Start in python/README.md.
+Original error:
+{traceback.format_exc()}
         """)
     sys.exit(1)
 

--- a/python/samples/perform_sql_batch_migration.py
+++ b/python/samples/perform_sql_batch_migration.py
@@ -4,27 +4,23 @@ from typing import Any, Optional
 
 try:
     import asyncio
-    from tempfile import NamedTemporaryFile
-    import uuid
     import os
     import sys
+    import uuid
+    from tempfile import NamedTemporaryFile
 
     # Add ../ to the path for PIP, so we can use absolute imports in the samples.
     sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
     import argparse
-    import asyncio
     import os
-    import uuid
-    from tempfile import NamedTemporaryFile
 
     import temporalio.service
 
-    from batch_orchestra.batch_orchestrator_io import BatchOrchestratorProgress
     from batch_orchestra.batch_orchestrator import BatchOrchestratorInput
-    from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient,  BatchOrchestratorHandle
-
-    from samples.lib.inflate_product_prices_page_processor import InflateProductPrices, ConfigArgs
+    from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
+    from batch_orchestra.batch_orchestrator_io import BatchOrchestratorProgress
+    from samples.lib.inflate_product_prices_page_processor import ConfigArgs, InflateProductPrices
     from samples.lib.product_db import ProductDB
 except ModuleNotFoundError as e:
     print(f"""

--- a/python/samples/perform_sql_batch_migration.py
+++ b/python/samples/perform_sql_batch_migration.py
@@ -16,6 +16,7 @@ try:
     import os
 
     import temporalio.service
+    from temporalio.client import Client
 
     from batch_orchestra.batch_orchestrator import BatchOrchestratorInput
     from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle

--- a/python/samples/run_workers.py
+++ b/python/samples/run_workers.py
@@ -3,8 +3,8 @@ try:
     import asyncio
     import logging
     import multiprocessing
-    import sys
     import os
+    import sys
 
     # Add ../ to the path for PIP, so we can use absolute imports in the samples.
     sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
@@ -14,12 +14,11 @@ try:
     from temporalio.client import Client
     from temporalio.worker import Worker
 
-    from batch_orchestra.batch_orchestrator import BatchOrchestrator, process_page
-    from batch_orchestra.batch_worker import BatchWorkerClient
-
     # Import our registry of page processors which are registered with @page_processor.
     # Without importing this, they will not be registered.
     import samples.lib.inflate_product_prices_page_processor  # noqa: F401
+    from batch_orchestra.batch_orchestrator import BatchOrchestrator, process_page
+    from batch_orchestra.batch_worker import BatchWorkerClient
 except ModuleNotFoundError as e:
     print(f"""
         This script requires poetry.  `poetry run python samples/run_workers.py`.

--- a/python/samples/run_workers.py
+++ b/python/samples/run_workers.py
@@ -4,11 +4,18 @@ try:
     import logging
     import multiprocessing
     import sys
+    import os
+
+    # Add ../ to the path for PIP, so we can use absolute imports in the samples.
+    sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
     from batch_orchestrator import BatchOrchestrator, process_page
     from batch_worker import BatchWorkerClient
     from temporalio.client import Client
     from temporalio.worker import Worker
+
+    from batch_orchestra.batch_orchestrator import BatchOrchestrator, process_page
+    from batch_orchestra.batch_worker import BatchWorkerClient
 
     # Import our registry of page processors which are registered with @page_processor.
     # Without importing this, they will not be registered.

--- a/python/samples/run_workers.py
+++ b/python/samples/run_workers.py
@@ -9,8 +9,6 @@ try:
     # Add ../ to the path for PIP, so we can use absolute imports in the samples.
     sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
-    from batch_orchestrator import BatchOrchestrator, process_page
-    from batch_worker import BatchWorkerClient
     from temporalio.client import Client
     from temporalio.worker import Worker
 

--- a/python/samples/run_workers.py
+++ b/python/samples/run_workers.py
@@ -17,11 +17,14 @@ try:
     import samples.lib.inflate_product_prices_page_processor  # noqa: F401
     from batch_orchestra.batch_orchestrator import BatchOrchestrator, process_page
     from batch_orchestra.batch_worker import BatchWorkerClient
-except ModuleNotFoundError as e:
+except ModuleNotFoundError:
+    import traceback
     print(f"""
-        This script requires poetry.  `poetry run python samples/run_workers.py`.
-        But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry.
-        Original error: {e}
+Failed to import modules.
+If you're using poetry, run `poetry run python samples/run_workers.py`.
+To set up poetry, or alternatively to set up a virtual environment, first see Python Quick Start in python/README.md.
+Original error:
+{traceback.format_exc()}
     """)
     sys.exit(1)
 

--- a/python/samples/set_sql_batch_migration_parallelism.py
+++ b/python/samples/set_sql_batch_migration_parallelism.py
@@ -2,6 +2,7 @@ import sys
 
 try:
     import argparse
+    from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
     import asyncio
 
     from batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle

--- a/python/samples/set_sql_batch_migration_parallelism.py
+++ b/python/samples/set_sql_batch_migration_parallelism.py
@@ -2,11 +2,12 @@ import sys
 
 try:
     import argparse
-    from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
     import asyncio
 
     from batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
     from temporalio.client import Client
+
+    from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
 except ModuleNotFoundError as e:
     print(f"""
 This script requires poetry.  `poetry run python samples/perform_sql_batch_migration.py`.

--- a/python/samples/set_sql_batch_migration_parallelism.py
+++ b/python/samples/set_sql_batch_migration_parallelism.py
@@ -4,7 +4,6 @@ try:
     import argparse
     import asyncio
 
-    from batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
     from temporalio.client import Client
 
     from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle

--- a/python/samples/set_sql_batch_migration_parallelism.py
+++ b/python/samples/set_sql_batch_migration_parallelism.py
@@ -7,11 +7,14 @@ try:
     from temporalio.client import Client
 
     from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
-except ModuleNotFoundError as e:
+except ModuleNotFoundError:
+    import traceback
     print(f"""
-This script requires poetry.  `poetry run python samples/perform_sql_batch_migration.py`.
-But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry.
-Original error: {e}
+Failed to import modules.
+If you're using poetry, run `poetry run python samples/perform_sql_batch_migration.py`.
+To set up poetry, or alternatively to set up a virtual environment, first see Python Quick Start in python/README.md.
+Original error:
+{traceback.format_exc()}
         """)
     sys.exit(1)
 

--- a/python/tests/batch_orchestrator_test.py
+++ b/python/tests/batch_orchestrator_test.py
@@ -21,12 +21,15 @@ try:
     from batch_orchestra.batch_orchestrator import BatchOrchestrator, BatchOrchestratorInput, process_page
     from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
     from batch_orchestra.batch_processor import BatchPage, BatchProcessorContext, PageProcessor, page_processor
-except ModuleNotFoundError as e:
-    print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")
-    print(
-        "But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry."
-    )
-    print(f"Original error: {e}")
+except ModuleNotFoundError:
+    import traceback
+    print(f"""
+Failed to import modules.
+If you're using poetry, run `poetry run pytest tests/batch_orchestrator_test.py`.
+To set up poetry, or alternatively to set up a virtual environment, first see Python Quick Start in python/README.md.
+Original error:
+{traceback.format_exc()}
+        """)
     sys.exit(1)
 
 

--- a/python/tests/batch_orchestrator_test.py
+++ b/python/tests/batch_orchestrator_test.py
@@ -11,16 +11,15 @@ try:
     from datetime import datetime, timedelta
     from typing import Optional
 
+    from temporalio.client import Client, WorkflowContinuedAsNewError, WorkflowFailureError, WorkflowHandle
     from temporalio.common import RetryPolicy
-    from temporalio.client import Client, WorkflowHandle, WorkflowFailureError, WorkflowContinuedAsNewError
-    from temporalio.worker import Worker
     from temporalio.exceptions import ApplicationError, TimeoutError
     from temporalio.service import RPCError
+    from temporalio.worker import Worker
 
-    from batch_orchestra.batch_processor import BatchPage
     from batch_orchestra.batch_orchestrator import BatchOrchestrator, BatchOrchestratorInput, process_page
     from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
-    from batch_orchestra.batch_processor import BatchProcessorContext, page_processor, PageProcessor
+    from batch_orchestra.batch_processor import BatchPage, BatchProcessorContext, PageProcessor, page_processor
 except ModuleNotFoundError as e:
     print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")
     print(

--- a/python/tests/batch_orchestrator_test.py
+++ b/python/tests/batch_orchestrator_test.py
@@ -11,15 +11,16 @@ try:
     from datetime import datetime, timedelta
     from typing import Optional
 
-    import pytest
-    from batch_orchestrator import BatchOrchestrator, BatchOrchestratorInput, process_page
-    from batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
-    from batch_processor import BatchPage, BatchProcessorContext, PageProcessor, page_processor
-    from temporalio.client import Client, WorkflowContinuedAsNewError, WorkflowFailureError, WorkflowHandle
     from temporalio.common import RetryPolicy
+    from temporalio.client import Client, WorkflowHandle, WorkflowFailureError, WorkflowContinuedAsNewError
+    from temporalio.worker import Worker
     from temporalio.exceptions import ApplicationError, TimeoutError
     from temporalio.service import RPCError
-    from temporalio.worker import Worker
+
+    from batch_orchestra.batch_processor import BatchPage
+    from batch_orchestra.batch_orchestrator import BatchOrchestrator, BatchOrchestratorInput, process_page
+    from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient, BatchOrchestratorHandle
+    from batch_orchestra.batch_processor import BatchProcessorContext, page_processor, PageProcessor
 except ModuleNotFoundError as e:
     print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")
     print(
@@ -747,9 +748,9 @@ async def test_logging(client: Client):
 
     async with batch_worker(client, task_queue_name):
         log_capture = MyHandler()
-        workflow_logger = logging.getLogger("batch_orchestrator")
+        workflow_logger = logging.getLogger('batch_orchestra.batch_orchestrator')
         workflow_logger.addHandler(log_capture)
-        activity_logger = logging.getLogger("batch_processor")
+        activity_logger = logging.getLogger('batch_orchestra.batch_processor')
         activity_logger.addHandler(log_capture)
 
         input = BatchOrchestratorInput(

--- a/python/tests/batch_orchestrator_test.py
+++ b/python/tests/batch_orchestrator_test.py
@@ -11,6 +11,7 @@ try:
     from datetime import datetime, timedelta
     from typing import Optional
 
+    import pytest
     from temporalio.client import Client, WorkflowContinuedAsNewError, WorkflowFailureError, WorkflowHandle
     from temporalio.common import RetryPolicy
     from temporalio.exceptions import ApplicationError, TimeoutError

--- a/python/tests/batch_orchestrator_with_tracker_test.py
+++ b/python/tests/batch_orchestrator_with_tracker_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 
-from batch_orchestrator_client import BatchOrchestratorClient
+from batch_orchestra.batch_orchestrator_client import BatchOrchestratorClient
 
 try:
     import json
@@ -11,12 +11,16 @@ try:
     from dataclasses import asdict, dataclass
 
     import pytest
-    from batch_orchestrator import BatchOrchestrator, BatchOrchestratorInput, process_page
-    from batch_processor import BatchProcessorContext, PageProcessor, page_processor
-    from batch_tracker import BatchTrackerContext, batch_tracker, track_batch_progress
+    import uuid    
+    
     from temporalio.client import Client, WorkflowHandle
-    from temporalio.common import RetryPolicy
     from temporalio.worker import Worker
+    from temporalio.common import RetryPolicy
+
+
+    from batch_orchestra.batch_processor import BatchProcessorContext, page_processor, PageProcessor
+    from batch_orchestra.batch_orchestrator import BatchOrchestrator, BatchOrchestratorInput, process_page
+    from batch_orchestra.batch_tracker import BatchTrackerContext, batch_tracker, track_batch_progress
 except ModuleNotFoundError as e:
     print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")
     print(

--- a/python/tests/batch_orchestrator_with_tracker_test.py
+++ b/python/tests/batch_orchestrator_with_tracker_test.py
@@ -11,15 +11,12 @@ try:
     from dataclasses import asdict, dataclass
 
     import pytest
-    import uuid    
-    
     from temporalio.client import Client, WorkflowHandle
-    from temporalio.worker import Worker
     from temporalio.common import RetryPolicy
+    from temporalio.worker import Worker
 
-
-    from batch_orchestra.batch_processor import BatchProcessorContext, page_processor, PageProcessor
     from batch_orchestra.batch_orchestrator import BatchOrchestrator, BatchOrchestratorInput, process_page
+    from batch_orchestra.batch_processor import BatchProcessorContext, PageProcessor, page_processor
     from batch_orchestra.batch_tracker import BatchTrackerContext, batch_tracker, track_batch_progress
 except ModuleNotFoundError as e:
     print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")

--- a/python/tests/batch_orchestrator_with_tracker_test.py
+++ b/python/tests/batch_orchestrator_with_tracker_test.py
@@ -18,14 +18,16 @@ try:
     from batch_orchestra.batch_orchestrator import BatchOrchestrator, BatchOrchestratorInput, process_page
     from batch_orchestra.batch_processor import BatchProcessorContext, PageProcessor, page_processor
     from batch_orchestra.batch_tracker import BatchTrackerContext, batch_tracker, track_batch_progress
-except ModuleNotFoundError as e:
-    print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")
-    print(
-        "But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry."
-    )
-    print(f"Original error: {e}")
+except ModuleNotFoundError:
+    import traceback
+    print(f"""
+Failed to import modules.
+If you're using poetry, run `poetry run pytest ./tests/batch_orchestrator_with_tracker_test.py`.
+To set up poetry, or alternatively to set up a virtual environment, first see Python Quick Start in python/README.md.
+Original error:
+{traceback.format_exc()}
+        """)
     sys.exit(1)
-
 
 def default_cursor():
     return MyCursor(0).to_json()

--- a/python/tests/batch_processor_test.py
+++ b/python/tests/batch_processor_test.py
@@ -10,6 +10,8 @@ try:
     import pytest
     import temporalio.common
     import temporalio.exceptions
+    from temporalio.client import Client, WorkflowHandle
+    from temporalio.testing import ActivityEnvironment
 
     from batch_orchestra.batch_processor import (
         BatchPage,

--- a/python/tests/batch_processor_test.py
+++ b/python/tests/batch_processor_test.py
@@ -10,10 +10,9 @@ try:
     import pytest
     import temporalio.common
     import temporalio.exceptions
-    from batch_processor import BatchPage, BatchProcessorContext, PageProcessor, page_processor, process_page
-    from batch_worker import BatchWorkerClient
-    from temporalio.client import Client, WorkflowHandle
-    from temporalio.testing import ActivityEnvironment
+
+    from batch_orchestra.batch_worker import BatchWorkerClient
+    from batch_orchestra.batch_processor import BatchProcessorContext, BatchPage, page_processor, process_page, PageProcessor
 except ModuleNotFoundError as e:
     print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")
     print(

--- a/python/tests/batch_processor_test.py
+++ b/python/tests/batch_processor_test.py
@@ -11,8 +11,14 @@ try:
     import temporalio.common
     import temporalio.exceptions
 
+    from batch_orchestra.batch_processor import (
+        BatchPage,
+        BatchProcessorContext,
+        PageProcessor,
+        page_processor,
+        process_page,
+    )
     from batch_orchestra.batch_worker import BatchWorkerClient
-    from batch_orchestra.batch_processor import BatchProcessorContext, BatchPage, page_processor, process_page, PageProcessor
 except ModuleNotFoundError as e:
     print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")
     print(

--- a/python/tests/batch_processor_test.py
+++ b/python/tests/batch_processor_test.py
@@ -21,14 +21,16 @@ try:
         process_page,
     )
     from batch_orchestra.batch_worker import BatchWorkerClient
-except ModuleNotFoundError as e:
-    print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")
-    print(
-        "But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry."
-    )
-    print(f"Original error: {e}")
+except ModuleNotFoundError:
+    import traceback
+    print(f"""
+Failed to import modules.
+If you're using poetry, run `poetry run pytest ./tests/batch_processor_test.py`.
+To set up poetry, or alternatively to set up a virtual environment, first see Python Quick Start in python/README.md.
+Original error:
+{traceback.format_exc()}
+        """)
     sys.exit(1)
-
 
 async def run_page_processor(
     page_processor_name: Type,

--- a/python/tests/batch_tracker_test.py
+++ b/python/tests/batch_tracker_test.py
@@ -20,14 +20,16 @@ try:
     )
     from batch_orchestra.batch_worker import BatchWorkerClient
 
-except ModuleNotFoundError as e:
-    print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")
-    print(
-        "But if you haven't, first see Python Quick Start in python/README.md for instructions on installing and setting up poetry."
-    )
-    print(f"Original error: {e}")
+except ModuleNotFoundError:
+    import traceback
+    print(f"""
+Failed to import modules.
+If you're using poetry, run `poetry run pytest ./tests/batch_tracker_test.py`.
+To set up poetry, or alternatively to set up a virtual environment, first see Python Quick Start in python/README.md.
+Original error:
+{traceback.format_exc()}
+        """)
     sys.exit(1)
-
 
 async def init_client():
     client = await Client.connect("localhost:7233")

--- a/python/tests/batch_tracker_test.py
+++ b/python/tests/batch_tracker_test.py
@@ -8,12 +8,16 @@ try:
     from unittest.mock import patch
 
     import pytest
-
-    from temporalio.client import WorkflowHandle, Client
+    from temporalio.client import Client, WorkflowHandle
     from temporalio.testing import ActivityEnvironment
 
     from batch_orchestra.batch_orchestrator_io import BatchOrchestratorProgress
-    from batch_orchestra.batch_tracker import batch_tracker, track_batch_progress, BatchTrackerContext, BatchTrackerKeepPolling
+    from batch_orchestra.batch_tracker import (
+        BatchTrackerContext,
+        BatchTrackerKeepPolling,
+        batch_tracker,
+        track_batch_progress,
+    )
     from batch_orchestra.batch_worker import BatchWorkerClient
 
 except ModuleNotFoundError as e:

--- a/python/tests/batch_tracker_test.py
+++ b/python/tests/batch_tracker_test.py
@@ -8,11 +8,13 @@ try:
     from unittest.mock import patch
 
     import pytest
-    from batch_orchestrator_io import BatchOrchestratorProgress
-    from batch_tracker import BatchTrackerContext, BatchTrackerKeepPolling, batch_tracker, track_batch_progress
-    from batch_worker import BatchWorkerClient
-    from temporalio.client import Client, WorkflowHandle
+
+    from temporalio.client import WorkflowHandle, Client
     from temporalio.testing import ActivityEnvironment
+
+    from batch_orchestra.batch_orchestrator_io import BatchOrchestratorProgress
+    from batch_orchestra.batch_tracker import batch_tracker, track_batch_progress, BatchTrackerContext, BatchTrackerKeepPolling
+    from batch_orchestra.batch_worker import BatchWorkerClient
 
 except ModuleNotFoundError as e:
     print("This script requires poetry.  Try `poetry run pytest ./tests/batch_orchestrator_test.py`.")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,7 +1,13 @@
 import asyncio
 import multiprocessing
 import sys
+import os
+
+# Add ../ to the path for PIP, so we can use absolute imports in the tests.
+sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
+
 from typing import AsyncGenerator
+from batch_orchestra.batch_worker import BatchWorkerClient
 
 import pytest
 import pytest_asyncio

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,19 +1,20 @@
 import asyncio
 import multiprocessing
-import sys
 import os
+import sys
 
 # Add ../ to the path for PIP, so we can use absolute imports in the tests.
 sys.path.insert(0, os.path.abspath(os.path.dirname(os.path.dirname(__file__))))
 
 from typing import AsyncGenerator
-from batch_orchestra.batch_worker import BatchWorkerClient
 
 import pytest
 import pytest_asyncio
 from batch_worker import BatchWorkerClient
 from temporalio.client import Client
 from temporalio.testing import WorkflowEnvironment
+
+from batch_orchestra.batch_worker import BatchWorkerClient
 
 #
 # This file was copied from https://github.com/temporalio/samples-python/blob/main/tests/conftest.py

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -10,7 +10,6 @@ from typing import AsyncGenerator
 
 import pytest
 import pytest_asyncio
-from batch_worker import BatchWorkerClient
 from temporalio.client import Client
 from temporalio.testing import WorkflowEnvironment
 


### PR DESCRIPTION
Import paths got annoying because pip and poetry include different directories in the path.

So, to be resilient, 
* I use absolute paths starting from the root from the samples and test directories.
* Use relative directories from within the module.

# Test plan

Follow instructions in the README.md to set up PIP/poetry.

Then
[poetry run] pytest ./tests 
[poetry run] python ./samples/perform_sql_batch_migration.py
[poetry run] python ./samples/run_workers.py

Test error messages from various scripts outside of a venv or poetry, e.g.:

`python ./samples/run_workers.py`
